### PR TITLE
Binds to nng_pipe_getopt_*()

### DIFF
--- a/nng.NETCore/Message.cs
+++ b/nng.NETCore/Message.cs
@@ -116,46 +116,29 @@ namespace nng
         public nng_pipe NngPipe { get; }
         public int Id => nng_pipe_id(NngPipe);
 
-        public bool GetOptionBool(string option)
+        public int GetOpt(string name, out bool data)
         {
-            nng_pipe_getopt_bool(NngPipe, option, out int val);
-            return val != 0;
+            int size = nng_pipe_getopt_bool(NngPipe, name, out int val);
+            data = val != 0;
+            return size;
         }
 
-        public int GetOptionInt(string option)
-        {
-            nng_pipe_getopt_int(NngPipe, option, out int val);
-            return val;
-        }
+        public int GetOpt(string name, out int data)
+            => nng_pipe_getopt_int(NngPipe, name, out data);
 
-        public int GetOptionMs(string option)
-        {
-            nng_pipe_getopt_ms(NngPipe, option, out int val);
-            return val;
-        }
+        public int GetOpt(string name, out nng_duration data)
+            => nng_pipe_getopt_ms(NngPipe, name, out data);
 
-        public UIntPtr GetOptionPtr(string option)
-        {
-            nng_pipe_getopt_ptr(NngPipe, option, out UIntPtr val);
-            return val;
-        }
+        public int GetOpt(string name, out IntPtr data)
+            => nng_pipe_getopt_ptr(NngPipe, name, out data);
 
-        public string GetOptionString(string option)
-        {
-            nng_pipe_getopt_string(NngPipe, option, out string val);
-            return val;
-        }
+        public int GetOpt(string name, out string data)
+            => nng_pipe_getopt_string(NngPipe, name, out data);
 
-        public UIntPtr GetOptionSize(string option)
-        {
-            nng_pipe_getopt_size(NngPipe, option, out UIntPtr val);
-            return val;
-        }
+        public int GetOpt(string name, out UIntPtr data)
+            => nng_pipe_getopt_size(NngPipe, name, out data);
 
-        public ulong GetOptionUInt64(string option)
-        {
-            nng_pipe_getopt_uint64(NngPipe, option, out ulong val);
-            return val;
-        }
+        public int GetOpt(string name, out ulong data)
+            => nng_pipe_getopt_uint64(NngPipe, name, out data);
     }
 }

--- a/nng.NETCore/Message.cs
+++ b/nng.NETCore/Message.cs
@@ -65,6 +65,8 @@ namespace nng
             return new Message(msg);
         }
 
+        public IPipe Pipe => _pipe ?? (_pipe = new Pipe(nng_msg_get_pipe(NngMsg)));
+
         public int Append(byte[] data) => nng_msg_append(NngMsg, data);
         public int Append(uint data) => nng_msg_append_u32(NngMsg, data);
         public int Chop(UIntPtr size) => nng_msg_chop(NngMsg, size);
@@ -79,6 +81,7 @@ namespace nng
 
         readonly nng_msg message;
         readonly NngMessageHeader _header;
+        Pipe _pipe;
 
         #region IDisposable
         public void Dispose()
@@ -101,5 +104,58 @@ namespace nng
         #endregion
 
         
+    }
+
+    public class Pipe : IPipe
+    {
+        public Pipe(nng_pipe pipe)
+        {
+            NngPipe = pipe;
+        }
+
+        public nng_pipe NngPipe { get; }
+        public int Id => nng_pipe_id(NngPipe);
+
+        public bool GetOptionBool(string option)
+        {
+            nng_pipe_getopt_bool(NngPipe, option, out int val);
+            return val != 0;
+        }
+
+        public int GetOptionInt(string option)
+        {
+            nng_pipe_getopt_int(NngPipe, option, out int val);
+            return val;
+        }
+
+        public int GetOptionMs(string option)
+        {
+            nng_pipe_getopt_ms(NngPipe, option, out int val);
+            return val;
+        }
+
+        public UIntPtr GetOptionPtr(string option)
+        {
+            nng_pipe_getopt_ptr(NngPipe, option, out UIntPtr val);
+            return val;
+        }
+
+        public string GetOptionString(string option)
+        {
+            nng_pipe_getopt_string(NngPipe, option, out string val);
+            return val;
+        }
+
+        public UIntPtr GetOptionSize(string option)
+        {
+            nng_pipe_getopt_size(NngPipe, option, out UIntPtr val);
+            return val;
+        }
+
+        public ulong GetOptionUInt64(string option)
+        {
+            nng_pipe_getopt_uint64(NngPipe, option, out ulong val);
+            return val;
+        }
     }
 }

--- a/nng.NETCore/Native/Msg.cs
+++ b/nng.NETCore/Native/Msg.cs
@@ -136,5 +136,29 @@ namespace nng.Native.Msg
 
         // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
         // public static extern int nng_msg_getopt(nng_msg message, Int32, IntPtr, UIntPtr);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_pipe_id(nng_pipe pipe);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_pipe_getopt_bool(nng_pipe pipe, string opt, out int val);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_pipe_getopt_int(nng_pipe pipe, string opt, out int val);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_pipe_getopt_ms(nng_pipe pipe, string opt, out int val);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_pipe_getopt_ptr(nng_pipe pipe, string opt, out UIntPtr val);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_pipe_getopt_string(nng_pipe pipe, string opt, out string val);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_pipe_getopt_size(nng_pipe pipe, string opt, out UIntPtr val);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_pipe_getopt_uint64(nng_pipe pipe, string opt, out ulong val);
     }
 }

--- a/nng.NETCore/Native/Msg.cs
+++ b/nng.NETCore/Native/Msg.cs
@@ -147,10 +147,10 @@ namespace nng.Native.Msg
         public static extern int nng_pipe_getopt_int(nng_pipe pipe, string opt, out int val);
 
         [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int nng_pipe_getopt_ms(nng_pipe pipe, string opt, out int val);
+        public static extern int nng_pipe_getopt_ms(nng_pipe pipe, string opt, out nng_duration val);
 
         [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int nng_pipe_getopt_ptr(nng_pipe pipe, string opt, out UIntPtr val);
+        public static extern int nng_pipe_getopt_ptr(nng_pipe pipe, string opt, out IntPtr val);
 
         [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
         public static extern int nng_pipe_getopt_string(nng_pipe pipe, string opt, out string val);

--- a/nng.Shared/Core.cs
+++ b/nng.Shared/Core.cs
@@ -60,6 +60,34 @@ namespace nng
         /// </summary>
         /// <returns>The newly created identical message duplicate</returns>
         IMessage Dup();
+        /// <summary>
+        /// Get the pipe object associated with the message.
+        /// </summary>
+        IPipe Pipe { get; }
+    }
+
+    /// <summary>
+    /// Handle to a "pipe", which can be thought of as a single connection.
+    /// </summary>
+    public interface IPipe
+    {
+        /// <summary>
+        /// Get the underlying nng_pipe.
+        /// </summary>
+        nng_pipe NngPipe { get; }
+
+        /// <summary>
+        /// A positive identifier for the pipe, if it is valid.
+        /// </summary>
+        int Id { get; }
+
+        bool GetOptionBool(string option);
+        int GetOptionInt(string option);
+        int GetOptionMs(string option);
+        UIntPtr GetOptionPtr(string option);
+        string GetOptionString(string option);
+        UIntPtr GetOptionSize(string option);
+        ulong GetOptionUInt64(string option);
     }
 
     public static class Extensions

--- a/nng.Shared/Core.cs
+++ b/nng.Shared/Core.cs
@@ -81,13 +81,13 @@ namespace nng
         /// </summary>
         int Id { get; }
 
-        bool GetOptionBool(string option);
-        int GetOptionInt(string option);
-        int GetOptionMs(string option);
-        UIntPtr GetOptionPtr(string option);
-        string GetOptionString(string option);
-        UIntPtr GetOptionSize(string option);
-        ulong GetOptionUInt64(string option);
+        int GetOpt(string name, out bool data);
+        int GetOpt(string name, out int data);
+        int GetOpt(string name, out nng_duration data);
+        int GetOpt(string name, out IntPtr data);
+        int GetOpt(string name, out string data);
+        int GetOpt(string name, out UIntPtr data);
+        int GetOpt(string name, out ulong data);
     }
 
     public static class Extensions

--- a/tests/MsgTests.cs
+++ b/tests/MsgTests.cs
@@ -169,5 +169,19 @@ namespace nng.Tests
             ChopTrimPart(msg);
             ChopTrimPart(msg.Header);
         }
+
+        [Fact]
+        public void Pipe()
+        {
+            var msg = factory.CreateMessage();
+            Assert.Equal(-1, msg.Pipe.Id);
+            Assert.False(msg.Pipe.GetOptionBool("option-name"));
+            Assert.Equal(0, msg.Pipe.GetOptionInt("option-name"));
+            Assert.Equal(0, msg.Pipe.GetOptionMs("option-name"));
+            Assert.Equal(UIntPtr.Zero, msg.Pipe.GetOptionPtr("option-name"));
+            Assert.Null(msg.Pipe.GetOptionString("option-name"));
+            Assert.Equal(UIntPtr.Zero, msg.Pipe.GetOptionSize("option-name"));
+            Assert.Equal(0UL, msg.Pipe.GetOptionUInt64("option-name"));
+        }
     }
 }

--- a/tests/MsgTests.cs
+++ b/tests/MsgTests.cs
@@ -175,13 +175,35 @@ namespace nng.Tests
         {
             var msg = factory.CreateMessage();
             Assert.Equal(-1, msg.Pipe.Id);
-            Assert.False(msg.Pipe.GetOptionBool("option-name"));
-            Assert.Equal(0, msg.Pipe.GetOptionInt("option-name"));
-            Assert.Equal(0, msg.Pipe.GetOptionMs("option-name"));
-            Assert.Equal(UIntPtr.Zero, msg.Pipe.GetOptionPtr("option-name"));
-            Assert.Null(msg.Pipe.GetOptionString("option-name"));
-            Assert.Equal(UIntPtr.Zero, msg.Pipe.GetOptionSize("option-name"));
-            Assert.Equal(0UL, msg.Pipe.GetOptionUInt64("option-name"));
+
+            int result;
+            result = msg.Pipe.GetOpt("option-name", out bool boolData);
+            Assert.NotEqual(0, result);
+            Assert.False(boolData);
+
+            result = msg.Pipe.GetOpt("option-name", out int intData);
+            Assert.NotEqual(0, result);
+            Assert.Equal(0, intData);
+
+            result = msg.Pipe.GetOpt("option-name", out nng_duration msData);
+            Assert.NotEqual(0, result);
+            Assert.Equal(default(nng_duration), msData);
+
+            result = msg.Pipe.GetOpt("option-name", out IntPtr ptr);
+            Assert.NotEqual(0, result);
+            Assert.Equal(IntPtr.Zero, ptr);
+
+            result = msg.Pipe.GetOpt("option-name", out string strData);
+            Assert.NotEqual(0, result);
+            Assert.Null(strData);
+
+            result = msg.Pipe.GetOpt("option-name", out UIntPtr sizeData);
+            Assert.NotEqual(0, result);
+            Assert.Equal(UIntPtr.Zero, sizeData);
+
+            result = msg.Pipe.GetOpt("option-name", out ulong ulongData);
+            Assert.NotEqual(0, result);
+            Assert.Equal(0UL, ulongData);
         }
     }
 }


### PR DESCRIPTION
This patch adds the lowest-level minimum bindings to [`nng_pipe_getopt_*()` functions][1] except for `nng_pipe_getopt_sockaddr()`.  In case of `nng_pipe_getopt_sockaddr()`,  as [`nng_sockaddr` type][2] also needs to be declared, I omitted it in this patch; I wish continuous working on that in the near future.  On the other hand, although I wrote some unit tests, frankly it's not satisfying myself, but I am not sure how can I have fixture of more realistic message objects which contains the actual pipe in unit tests, so I stopped there.

[1]: https://nanomsg.github.io/nng/man/v1.1.0/nng_pipe_getopt.3
[2]: https://nanomsg.github.io/nng/man/v1.1.0/nng_sockaddr.5