### PR TITLE
Fix numerous tests (#26)

### DIFF
--- a/dockerfiles/dotnet-sdk/Dockerfile
+++ b/dockerfiles/dotnet-sdk/Dockerfile
@@ -8,6 +8,11 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     icu-devtools
 
+# https://docs.microsoft.com/en-us/nuget/tools/cli-ref-environment-variables
+ENV NUGET_XMLDOC_MODE skip
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
+
 # .NET Core 3.0
 # From:
 # https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/stretch/arm64v8/Dockerfile

--- a/nng.NETCore/AsyncContext.cs
+++ b/nng.NETCore/AsyncContext.cs
@@ -104,7 +104,6 @@ namespace nng
                 nng_aio_free(aioHandle);
                 var removed = callbacks.TryRemove(aioCallback, out var _);
                 System.Diagnostics.Debug.Assert(removed);
-                Socket.Dispose();
             }
             disposed = true;
         }

--- a/nng.Shared/AsyncBarrier.cs
+++ b/nng.Shared/AsyncBarrier.cs
@@ -40,6 +40,11 @@ namespace nng
             return tcs.Task;
         }
 
+        ///<summary>
+        /// SignalAndWait() may create a new TaskCompletionSource() for the next barrier and you may wait on the wrong one.
+        ///</summary>
+        public Task WaitAsync() => m_tcs.Task;
+
         private readonly int m_participantCount;
         private TaskCompletionSource<bool> m_tcs = new TaskCompletionSource<bool>();
         private int m_remainingParticipants;

--- a/nng.Shared/Core.cs
+++ b/nng.Shared/Core.cs
@@ -111,7 +111,7 @@ namespace nng
         }
         public static CancellationTokenTaskSource<NngResult<T>> CreateReceiveSource<T>(CancellationToken token)
         {
-            return new CancellationTokenTaskSource<NngResult<T>>(token);
+            return new CancellationTokenTaskSource<NngResult<T>>(token, TaskCreationOptions.RunContinuationsAsynchronously);
         }
         public static TaskCompletionSource<NngResult<Unit>> CreateSendResultSource()
         {

--- a/nng.Shared/Defines.cs
+++ b/nng.Shared/Defines.cs
@@ -200,6 +200,24 @@ namespace nng.Native
             TimeMs = copy.TimeMs;
         }
 
+        
+        ///<sumary>
+        /// a context-specific default value should be used.  See `NNG_DURATION_INFINITE`.
+        ///</summary>
+        public static ref readonly nng_duration Infinite => ref infinite;
+        ///<sumary>
+        /// a context-specific default value should be used.  See `NNG_DURATION_DEFAULT`.
+        ///</summary>
+        public static ref readonly nng_duration Default => ref defaultDuration;
+        ///<sumary>
+        /// a context-specific default value should be used.  See `NNG_DURATION_ZERO`.
+        ///</summary>
+        public static ref readonly nng_duration Zero => ref zero;
+        
+        static readonly nng_duration infinite = new nng_duration { TimeMs = Defines.NNG_DURATION_INFINITE };
+        static readonly nng_duration defaultDuration = new nng_duration { TimeMs = Defines.NNG_DURATION_DEFAULT };
+        static readonly nng_duration zero = new nng_duration { TimeMs = Defines.NNG_DURATION_ZERO };
+
         public static nng_duration operator +(nng_duration lhs, nng_duration rhs) =>
             new nng_duration { TimeMs = lhs.TimeMs + rhs.TimeMs };
 

--- a/tests/Fixtures.cs
+++ b/tests/Fixtures.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace nng.Tests
 {
@@ -44,5 +45,41 @@ namespace nng.Tests
     [CollectionDefinition("nng")]
     public class NngCollection : ICollectionFixture<NngCollectionFixture>
     {
+    }
+
+    // using Xunit.Abstractions;
+    // [Collection("nng")]
+    // public class PubSubTests
+    // {
+    //     public PubSubTests(ITestOutputHelper outputHelper)
+    //     {
+    //         Converter.Register(outputHelper);
+    //     }
+    //https://stackoverflow.com/questions/7138935/xunit-net-does-not-capture-console-output/47529356#47529356
+    internal class Converter : TextWriter
+    {
+        public static void Register(ITestOutputHelper outputHelper)
+        {
+            var converter = new Converter(outputHelper ?? throw new ArgumentNullException(nameof(outputHelper)));
+            System.Console.SetOut(converter);
+        }
+
+        ITestOutputHelper _output;
+        public Converter(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+        public override System.Text.Encoding Encoding
+        {
+            get { return System.Text.Encoding.UTF8; }
+        }
+        public override void WriteLine(string message)
+        {
+            _output.WriteLine(message);
+        }
+        public override void WriteLine(string format, params object[] args)
+        {
+            _output.WriteLine(format, args);
+        }
     }
 }

--- a/tests/ReqRepTests.cs
+++ b/tests/ReqRepTests.cs
@@ -46,21 +46,23 @@ namespace nng.Tests
             var barrier = new AsyncBarrier(2);
             var rep = Task.Run(async () =>
             {
-                using (var repAioCtx = Factory.ReplierCreate(url).Unwrap().CreateAsyncContext(Factory).Unwrap())
+                using (var socket = Factory.ReplierCreate(url).Unwrap())
+                using (var ctx = socket.CreateAsyncContext(Factory).Unwrap())
                 {
                     await barrier.SignalAndWait();
 
-                    var msg = await repAioCtx.Receive();
-                    (await repAioCtx.Reply(Factory.CreateMessage())).Unwrap();
+                    var msg = await ctx.Receive();
+                    (await ctx.Reply(Factory.CreateMessage())).Unwrap();
                     await WaitShort();
                 }
             });
             var req = Task.Run(async () =>
             {
                 await barrier.SignalAndWait();
-                using (var reqAioCtx = Factory.RequesterCreate(url).Unwrap().CreateAsyncContext(Factory).Unwrap())
+                using (var socket = Factory.RequesterCreate(url).Unwrap())
+                using (var ctx = socket.CreateAsyncContext(Factory).Unwrap())
                 {
-                    var _response = await reqAioCtx.Send(Factory.CreateMessage());
+                    var _response = await ctx.Send(Factory.CreateMessage());
                 }
             });
             return Util.AssertWait(req, rep);

--- a/tests/Util.cs
+++ b/tests/Util.cs
@@ -18,8 +18,8 @@ namespace nng.Tests
     }
     static class Util
     {
-        public const int ShortTestMs = 100;
-        public const int DefaultTimeoutMs = 1000;
+        public const int ShortTestMs = 250;
+        public const int DefaultTimeoutMs = 5000;
 
         public static string UrlIpc() => "ipc://" + Guid.NewGuid().ToString();
         public static string UrlInproc() => "inproc://" + Guid.NewGuid().ToString();
@@ -44,62 +44,13 @@ namespace nng.Tests
 
         public static Task CancelAfterAssertwait(CancellationTokenSource cts, params Task[] tasks)
         {
-            return CancelAfterAssertwait(tasks, cts, DefaultTimeoutMs);
+            return CancelAfterAssertwait(tasks, cts);
         }
 
-        public static Task CancelAfterAssertwait(IEnumerable<Task> tasks, CancellationTokenSource cts, int timeoutMs = DefaultTimeoutMs)
+        public static Task CancelAfterAssertwait(IEnumerable<Task> tasks, CancellationTokenSource cts, int cancelAfterMs = ShortTestMs, int timeoutMs = DefaultTimeoutMs)
         {
-            cts.CancelAfter(timeoutMs);
+            cts.CancelAfter(cancelAfterMs);
             return AssertWait(tasks, timeoutMs);
-        }
-
-        public static async Task CancelAndWait(IEnumerable<Task> tasks, CancellationTokenSource cts, int timeoutMs)
-        {
-            cts.Cancel();
-            try
-            {
-                var timeout = Task.Delay(timeoutMs);
-                Assert.NotEqual(timeout, await Task.WhenAny(timeout, Task.WhenAll(tasks)));
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                {
-                    // ok
-                }
-                else
-                {
-                    throw ex;
-                }
-            }
-        }
-
-        public static Task CancelAfterAndWait(CancellationTokenSource cts, int timeoutMs, params Task[] tasks)
-        {
-            return CancelAfterAndWait(tasks, cts, timeoutMs);
-        }
-
-        public static async Task CancelAfterAndWait(IEnumerable<Task> tasks, CancellationTokenSource cts, int timeoutMs)
-        {
-            if (timeoutMs > DefaultTimeoutMs)
-                throw new ArgumentException();
-            cts.CancelAfter(timeoutMs);
-            try
-            {
-                var timeout = Task.Delay(DefaultTimeoutMs);
-                Assert.NotEqual(timeout, await Task.WhenAny(timeout, Task.WhenAll(tasks)));
-            }
-            catch (Exception ex)
-            {
-                if (ex is TaskCanceledException)
-                {
-                    // Timedout
-                }
-                else
-                {
-                    throw ex;
-                }
-            }
         }
 
         public static bool BytesEqual(ReadOnlySpan<byte> lhs, ReadOnlySpan<byte> rhs)


### PR DESCRIPTION
- AsyncContext cannot dispose socket since it may be shared with other aio/ctx
- Tests must explicity dispose sockets since we're reusing URLs otherwise things timeout
- TaskCompletionSource continuations should be asynchronous to avoid certain deadlocks
- Test timeout increased to more generous 5s to reduce spurious failures