### PR TITLE
Dialer/listener improvements

### DIFF
--- a/nng.NETCore/Dialer.cs
+++ b/nng.NETCore/Dialer.cs
@@ -25,6 +25,11 @@ namespace nng
             return new Dialer { NngDialer = dialer };
         }
 
+        public static IDialer Create(nng_dialer dialer)
+        {
+            return new Dialer { NngDialer = dialer };
+        }
+
         public int Start(NngFlag flags)
             => nng_dialer_start(NngDialer, flags);
 

--- a/nng.NETCore/Factory.cs
+++ b/nng.NETCore/Factory.cs
@@ -40,30 +40,6 @@ namespace nng.Tests
         public NngResult<IPairSocket> PairOpen() => Pair1Socket.Open();
         public NngResult<IRespondentSocket> RespondentOpen() => RespondentSocket.Open();
         public NngResult<ISurveyorSocket> SurveyorOpen() => SurveyorSocket.Open();
-        public IListener ListenerCreate(ISocket socket, string url) => Listener.Create(socket, url);
-        public IDialer DialerCreate(ISocket socket, string url) => Dialer.Create(socket, url);
-
-        public NngResult<TSocket> Dial<TSocket>(NngResult<TSocket> socketRes, string url) where TSocket : ISocket
-        {
-            if (socketRes.TryOk(out var ok))
-            {
-                var res = nng_dial(ok.NngSocket, url, 0);
-                if (res != 0)
-                    return NngResult<TSocket>.Fail(res);
-            }
-            return socketRes;
-        }
-
-        public NngResult<TSocket> Listen<TSocket>(NngResult<TSocket> socketRes, string url) where TSocket : ISocket
-        {
-            if (socketRes.TryOk(out var ok))
-            {
-                var res = nng_listen(ok.NngSocket, url, 0);
-                if (res != 0)
-                    return NngResult<TSocket>.Fail(res);
-            }
-            return socketRes;
-        }
 
         #region IAsyncContextFactory
         public NngResult<ISendAsyncContext<IMessage>> CreateSendAsyncContext(ISocket socket)

--- a/nng.NETCore/Listener.cs
+++ b/nng.NETCore/Listener.cs
@@ -25,6 +25,11 @@ namespace nng
             return new Listener { NngListener = listener };
         }
 
+        public static IListener Create(nng_listener listener)
+        {
+            return new Listener { NngListener = listener };
+        }
+
         public int Start(NngFlag flags)
             => nng_listener_start(NngListener, flags);
 
@@ -38,6 +43,8 @@ namespace nng
             => nng_listener_getopt_ptr(NngListener, name, out data);
         public int GetOpt(string name, out UIntPtr data)
             => nng_listener_getopt_size(NngListener, name, out data);
+        public int GetOpt(string name, out nng_sockaddr data)
+            => nng_listener_getopt_sockaddr(NngListener, name, out data);
         public int GetOpt(string name, out string data)
         {
             IntPtr ptr;

--- a/nng.NETCore/Native/Listener.cs
+++ b/nng.NETCore/Native/Listener.cs
@@ -40,6 +40,9 @@ namespace nng.Native.Listener
         public static extern int nng_listener_getopt_size(nng_listener listener, string name, out UIntPtr data);
 
         [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int nng_listener_getopt_sockaddr(nng_listener listener, string name, out nng_sockaddr data);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
         public static extern int nng_listener_getopt_string(nng_listener listener, string name, out IntPtr data);
 
         [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]

--- a/nng.NETCore/Socket.cs
+++ b/nng.NETCore/Socket.cs
@@ -15,6 +15,25 @@ namespace nng
     {
         public nng_socket NngSocket { get; protected set; }
 
+        public NngResult<Unit> Dial(string url, Defines.NngFlag flags = default)
+            => Unit.OkIfZero(nng_dial(NngSocket, url, flags));
+        public NngResult<Unit> Listen(string url, Defines.NngFlag flags = default)
+            => Unit.OkIfZero(nng_listen(NngSocket, url, flags));
+        public NngResult<IListener> ListenWithListener(string url, Defines.NngFlag flags = default)
+        {
+            var res = nng_listen(NngSocket, url, out var listener, flags);
+            return NngResult<IListener>.OkThen(res, () => Listener.Create(listener));
+        }
+        public NngResult<IDialer> DialWithDialer(string url, Defines.NngFlag flags = default)
+        {
+            var res = nng_dial(NngSocket, url, out var dialer, flags);
+            return NngResult<IDialer>.OkThen(res, () => Dialer.Create(dialer));
+        }
+        public NngResult<IListener> ListenerCreate(string url)
+            => NngResult<IListener>.Ok(Listener.Create(this, url));
+        public NngResult<IDialer> DialerCreate(string url)
+            => NngResult<IDialer>.Ok(Dialer.Create(this, url));
+
         public int GetOpt(string name, out bool data)
             => nng_getopt_bool(NngSocket, name, out data);
         public int GetOpt(string name, out int data)

--- a/nng.Shared/Defines.cs
+++ b/nng.Shared/Defines.cs
@@ -6,6 +6,7 @@ namespace nng.Native
 {
     public sealed partial class Defines
     {
+        public const int NNG_MAXADDRLEN = 128;
 
         public const int NNG_DURATION_INFINITE = -1;
         public const int NNG_DURATION_DEFAULT = -2;
@@ -258,4 +259,116 @@ namespace nng.Native
 
         public bool IsNull => ptr == IntPtr.Zero;
     }
+
+#region sockaddr
+    public enum nng_sockaddr_family : UInt16
+    {
+        NNG_AF_UNSPEC = 0,
+        NNG_AF_INPROC = 1,
+        NNG_AF_IPC = 2,
+        NNG_AF_INET = 3,
+        NNG_AF_INET6 = 4,
+        NNG_AF_ZT = 5 // ZeroTier
+    };
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct nng_sockaddr
+    {
+        [FieldOffset(0)]
+        public nng_sockaddr_family s_family;
+        [FieldOffset(0)]
+        public nng_sockaddr_ipc s_ipc;
+        [FieldOffset(0)]
+        public nng_sockaddr_inproc s_inproc;
+        [FieldOffset(0)]
+        public nng_sockaddr_in6 s_in6;
+        [FieldOffset(0)]
+        public nng_sockaddr_in s_in;
+        [FieldOffset(0)]
+        public nng_sockaddr_zt s_zt;
+    };
+
+    /// <summary>
+    /// In nng this is a typedef:
+    /// typedef struct nng_sockaddr_path nng_sockaddr_ipc;
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_sockaddr_ipc
+    {
+        public nng_sockaddr_path sockaddr_path;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_sockaddr_inproc
+    {
+        public UInt16 sa_family;
+        char_maxaddrlen_blob sa_name;
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_sockaddr_in6
+    {
+        public nng_sockaddr_family sa_family;
+        public UInt16 sa_port;
+        uint8_16_blob sa_addr;
+    };
+
+    /// <summary>
+    /// In nng this is a typedef:
+    /// typedef struct nng_sockaddr_in6 nng_sockaddr_udp6;
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_sockaddr_udp6
+    {
+        public nng_sockaddr_in6 sockaddr_path;
+    }
+
+    /// <summary>
+    /// In nng this is a typedef:
+    /// typedef struct nng_sockaddr_in6 nng_sockaddr_tcp6;
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_sockaddr_tcp6
+    {
+        public nng_sockaddr_in6 sockaddr_path;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_sockaddr_in
+    {
+        public nng_sockaddr_family sa_family;
+        public UInt16 sa_port;
+        public UInt32 sa_addr;
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_sockaddr_zt
+    {
+        public nng_sockaddr_family sa_family;
+        public UInt64 sa_nwid;
+        public UInt64 sa_nodeid;
+        public UInt32 sa_port;
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_sockaddr_path
+    {
+        public nng_sockaddr_family sa_family;
+        char_maxaddrlen_blob sa_path;
+    };
+
+    // Could instead write sa_path member of nng_sockr_path as:
+    // fixed char sa_path[NNG_MAXADDRLEN];
+    // But `fixed` requires turn on unsafe code for whole assembly....
+    [StructLayout(LayoutKind.Sequential, Size = Defines.NNG_MAXADDRLEN)]
+    struct char_maxaddrlen_blob
+    {
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 16)]
+    struct uint8_16_blob
+    {
+    }
+
+#endregion
 }

--- a/nng.Shared/Factory.cs
+++ b/nng.Shared/Factory.cs
@@ -2,121 +2,36 @@ namespace nng
 {
     public static class FactoryExt
     {
-        /// <summary>
-        /// Create bus protocol node
-        /// </summary>
-        /// <returns>The create.</returns>
-        /// <param name="factory">Factory.</param>
-        /// <param name="url">URL.</param>
-        /// <param name="isListener">If set to <c>true</c> is listener.</param>
-        /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static NngResult<IBusSocket> BusCreate<T>(this IAPIFactory<T> factory, string url, bool isListener) => factory.DialOrListen(factory.BusOpen(), url, isListener);
-        /// <summary>
-        /// Create request node for request/reply protocol
-        /// </summary>
-        /// <returns>The create.</returns>
-        /// <param name="factory">Factory.</param>
-        /// <param name="url">URL.</param>
-        /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static NngResult<IReqSocket> RequesterCreate<T>(this IAPIFactory<T> factory, string url) => factory.Dial(factory.RequesterOpen(), url);
-        /// <summary>
-        /// Create reply node for request/reply protocol
-        /// </summary>
-        /// <returns>The create.</returns>
-        /// <param name="factory">Factory.</param>
-        /// <param name="url">URL.</param>
-        /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static NngResult<IRepSocket> ReplierCreate<T>(this IAPIFactory<T> factory, string url) => factory.Listen(factory.ReplierOpen(), url);
-        /// <summary>
-        /// Create publish node for publish/subscribe protocol
-        /// </summary>
-        /// <returns>The create.</returns>
-        /// <param name="factory">Factory.</param>
-        /// <param name="url">URL.</param>
-        /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static NngResult<IPubSocket> PublisherCreate<T>(this IAPIFactory<T> factory, string url) => factory.Listen(factory.PublisherOpen(), url);
-        /// <summary>
-        /// Create subscribe node for publish/subscribe protocol
-        /// </summary>
-        /// <returns>The create.</returns>
-        /// <param name="factory">Factory.</param>
-        /// <param name="url">URL.</param>
-        /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static NngResult<ISubSocket> SubscriberCreate<T>(this IAPIFactory<T> factory, string url) => factory.Dial(factory.SubscriberOpen(), url);
-        /// <summary>
-        /// Create push node for push/pull protocol
-        /// </summary>
-        /// <returns>The create.</returns>
-        /// <param name="factory">Factory.</param>
-        /// <param name="url">URL.</param>
-        /// <param name="isListener">If set to <c>true</c> is listener.</param>
-        /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static NngResult<IPushSocket> PusherCreate<T>(this IAPIFactory<T> factory, string url, bool isListener) => factory.DialOrListen(factory.PusherOpen(), url, isListener);
-        /// <summary>
-        /// Create pull node for push/pull protocol
-        /// </summary>
-        /// <returns>The create.</returns>
-        /// <param name="factory">Factory.</param>
-        /// <param name="url">URL.</param>
-        /// <param name="isListener">If set to <c>true</c> is listener.</param>
-        /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static NngResult<IPullSocket> PullerCreate<T>(this IAPIFactory<T> factory, string url, bool isListener) => factory.DialOrListen(factory.PullerOpen(), url, isListener);
-
-        /// <summary>
-        /// Create pair socket for pair protocol
-        /// </summary>
-        /// <param name="factory"></param>
-        /// <param name="url"></param>
-        /// <param name="isListener"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static NngResult<IPairSocket> PairCreate<T>(this IAPIFactory<T> factory, string url, bool isListener) => factory.DialOrListen(factory.PairOpen(), url, isListener);
-
-        /// <summary>
-        /// Create respondent socket for survey protocol
-        /// </summary>
-        /// <param name="factory"></param>
-        /// <param name="url"></param>
-        /// <param name="isListener"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static NngResult<IRespondentSocket> RespondentCreate<T>(this IAPIFactory<T> factory, string url, bool isListener) => factory.DialOrListen(factory.RespondentOpen(), url, isListener);
-
-        /// <summary>
-        /// Create surveyor socket for survey protocol
-        /// </summary>
-        /// <param name="factory"></param>
-        /// <param name="url"></param>
-        /// <param name="isListener"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static NngResult<ISurveyorSocket> SurveyorCreate<T>(this IAPIFactory<T> factory, string url, bool isListener) => factory.DialOrListen(factory.SurveyorOpen(), url, isListener);
-
-        /// <summary>
-        /// Creates a dialer or listener associated with a socket and starts it.
-        /// </summary>
-        /// <returns>The or listen.</returns>
-        /// <param name="factory">Factory used to dial/listen.</param>
-        /// <param name="socketRes">Socket the dialer/listener is associated with</param>
-        /// <param name="url">URL used by dialer/listener</param>
-        /// <param name="isListener">If set to <c>true</c> is listener, else is dialer</param>
-        /// <typeparam name="TSocket">The 1st type parameter.</typeparam>
-        /// <typeparam name="TMsg">The 2nd type parameter.</typeparam>
-        public static NngResult<TSocket> DialOrListen<TSocket, TMsg>(this IAPIFactory<TMsg> factory, NngResult<TSocket> socketRes, string url, bool isListener)
-            where TSocket : ISocket
+        public static NngResult<T> ThenListen<T>(this NngResult<T> result, string url, Native.Defines.NngFlag flags = default)
+            where T: ISocket
         {
-            if (socketRes.IsOk())
+            return result.Then(socket => socket.Listen(url, flags));
+        }
+
+        public static NngResult<T> ThenListenAs<T>(this NngResult<T> result, out IListener listener, string url, Native.Defines.NngFlag flags = default)
+            where T: ISocket
+        {
+            listener = null;
+            if (result.IsOk())
             {
-                if (isListener)
+                var socket = result.Ok();
+                var res = socket.ListenWithListener(url, flags);
+                if (res.IsOk())
                 {
-                    return factory.Listen<TSocket>(socketRes, url);
+                    listener = res.Ok();
                 }
                 else
                 {
-                    return factory.Dial<TSocket>(socketRes, url);
+                    return res.IntoErr<T>();
                 }
             }
-            return socketRes;
+            return result;
+        }
+
+        public static NngResult<T> ThenDial<T>(this NngResult<T> result, string url, Native.Defines.NngFlag flags = default)
+            where T: ISocket
+        {
+            return result.Then(socket => socket.Dial(url, flags));
         }
     }
 }

--- a/nng.Shared/IFactory.cs
+++ b/nng.Shared/IFactory.cs
@@ -28,12 +28,6 @@ namespace nng
         NngResult<IPairSocket> PairOpen();
         NngResult<IRespondentSocket> RespondentOpen();
         NngResult<ISurveyorSocket> SurveyorOpen();
-
-        IListener ListenerCreate(ISocket socket, string url);
-        IDialer DialerCreate(ISocket socket, string url);
-
-        NngResult<TSocket> Dial<TSocket>(NngResult<TSocket> socketRes, string url) where TSocket : ISocket;
-        NngResult<TSocket> Listen<TSocket>(NngResult<TSocket> socketRes, string url) where TSocket : ISocket;
     }
 
     public enum SendReceiveContextSubtype

--- a/nng.Shared/ISockets.cs
+++ b/nng.Shared/ISockets.cs
@@ -11,7 +11,49 @@ namespace nng
     public interface ISocket : IOptions, IDisposable
     {
         nng_socket NngSocket { get; }
+        
+        /// <summary>
+        /// Create and start a listener that listens at the specified url for incoming connections from dialers.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="flags"></param>
+        /// <returns></returns>
+        NngResult<Unit> Listen(string url, Defines.NngFlag flags = default);
+        /// <summary>
+        /// Create and start dialer that dials/connects to the specified url where a listener is listening.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="flags"></param>
+        /// <returns></returns>
+        NngResult<Unit> Dial(string url, Defines.NngFlag flags = default);
+        /// <summary>
+        /// Create and start a listener and return it.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="flags"></param>
+        /// <returns></returns>
+        NngResult<IListener> ListenWithListener(string url, Defines.NngFlag flags = default);
+        /// <summary>
+        /// Create and start a dialer and return it.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="flags"></param>
+        /// <returns></returns>
+        NngResult<IDialer> DialWithDialer(string url, Defines.NngFlag flags = default);
+        /// <summary>
+        /// Create a listener.  It must be started to begin listening.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        NngResult<IListener> ListenerCreate(string url);
+        /// <summary>
+        /// Create a dialer.  It must be started to dial and initiate a connection.
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        NngResult<IDialer> DialerCreate(string url);
     }
+
 
     public static class OptionsExt
     {
@@ -56,7 +98,9 @@ namespace nng
     /// Represents nng listener
     /// </summary>
     public interface IListener : IStart, IOptions
-    { }
+    {
+        int GetOpt(string name, out nng_sockaddr data);
+    }
 
     /// <summary>
     /// Represents nng dialer

--- a/nng.Shared/Result.cs
+++ b/nng.Shared/Result.cs
@@ -172,6 +172,20 @@ namespace nng
         /// <returns></returns>
         public NngErrno Err() => result.Err();
 
+        public NngResult<TOk> Then(Func<TOk, NngResult<Unit>> func)
+        {
+            if (IsOk())
+            {
+                var ok = Ok();
+                var res = func(ok);
+                return res.Into(() => ok);
+            }
+            else
+            {
+                return this;
+            }
+        }
+
         /// <summary>
         /// Create a result of another type.  If this is a success uses.
         /// If this is a fail, contains the same fail value.

--- a/tests/AioTests.cs
+++ b/tests/AioTests.cs
@@ -86,9 +86,13 @@ namespace nng.Tests
         async Task<(ISendAsyncContext<IMessage>, IReceiveAsyncContext<IMessage>)> CreatePusherAndPuller()
         {
             var url = UrlIpc();
-            var push = factory.PusherCreate(url, true).Unwrap().CreateAsyncContext(factory).Unwrap();
+            var pushSocket = factory.PusherOpen().Unwrap();
+            pushSocket.Listen(url).Unwrap();
+            var push = pushSocket.CreateAsyncContext(factory).Unwrap();
             await WaitReady();
-            var pull = factory.PullerCreate(url, false).Unwrap().CreateAsyncContext(factory).Unwrap();
+            var pullSocket = factory.PullerOpen().Unwrap();
+            pullSocket.Dial(url).Unwrap();
+            var pull = pullSocket.CreateAsyncContext(factory).Unwrap();
             return (push, pull);
         }
     }

--- a/tests/Broker.cs
+++ b/tests/Broker.cs
@@ -58,7 +58,7 @@ namespace nng.Tests
             {
                 var task = Task.Run(async () =>
                 {
-                    using (var socket = implementation.Factory.PusherCreate(inUrl, false).Unwrap())
+                    using (var socket = implementation.Factory.PusherOpen().ThenDial(inUrl).Unwrap())
                     using (var ctx = socket.CreateAsyncContext(implementation.Factory).Unwrap())
                     {
                         await clientsReady.SignalAndWait(); // This client ready, wait for rest

--- a/tests/CtxTests.cs
+++ b/tests/CtxTests.cs
@@ -26,7 +26,8 @@ namespace nng.Tests
         public void GetSetOpt()
         {
             var url = UrlIpc();
-            using (var rep = Factory.ReplierCreate(url).Unwrap().CreateAsyncContext(Factory).Unwrap())
+            using (var socket = Factory.ReplierOpen().ThenListen(url).Unwrap())
+            using (var rep = socket.CreateAsyncContext(Factory).Unwrap())
             {
                 var ctx = (rep as ICtx).Ctx;
                 // Get a value, set a new value, get back the new value

--- a/tests/DialerTests.cs
+++ b/tests/DialerTests.cs
@@ -28,16 +28,35 @@ namespace nng.Tests
             Fixture.TestIterate(() =>
             {
                 var url = UrlIpc();
-                using (var pub = Factory.PublisherCreate(url).Unwrap())
+                using (var pub = Factory.PublisherOpen().Unwrap())
                 {
-                    var socket = Factory.SubscriberOpen().Unwrap();
-                    using (var dialer = Factory.DialerCreate(socket, url))
+                    pub.Listen(url).Unwrap();
+                    using (var socket = Factory.SubscriberOpen().Unwrap())
+                    using (var dialer = socket.DialerCreate(url).Unwrap())
                     {
                         Assert.NotNull(dialer);
                         Assert.Equal(0, dialer.Start());
                     }
                 }
             });
+        }
+
+        [Theory]
+        [ClassData(typeof(TransportsClassData))]
+        public Task Nonblock(string url)
+        {
+            return Fixture.TestIterate(() => DoNonblock(url));
+        }
+
+        async Task DoNonblock(string url)
+        {
+            using (var pub = Factory.PublisherOpen().ThenListenAs(out var listener, url).Unwrap())
+            using (var sub = Factory.SubscriberOpen().Unwrap())
+            {
+                var dialUrl = GetDialUrl(listener, url);
+                var res = await RetryAgain(() => sub.Dial(dialUrl, Defines.NngFlag.NNG_FLAG_NONBLOCK));
+                res.Unwrap();
+            }
         }
     }
 }

--- a/tests/ListenerTests.cs
+++ b/tests/ListenerTests.cs
@@ -27,12 +27,32 @@ namespace nng.Tests
         {
             var url = UrlInproc();
             using (var socket = Factory.PublisherOpen().Unwrap())
-            using (var listener = Factory.ListenerCreate(socket, url))
+            using (var listener = socket.ListenerCreate(url).Unwrap())
             {
                 Assert.NotNull(listener);
                 Assert.Equal(0, listener.Start());
                 await WaitReady();
-                Assert.NotNull(Factory.SubscriberCreate(url));
+                var subSocket = Factory.SubscriberOpen().Unwrap();
+                Assert.NotNull(subSocket.DialerCreate(url));
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(TransportsClassData))]
+        public Task Nonblock(string url)
+        {
+            return Fixture.TestIterate(() => DoNonblock(url));
+        }
+
+        async Task DoNonblock(string url)
+        {
+            using (var pub = Factory.PublisherOpen().Unwrap())
+            {
+                var listener = await Util.RetryAgain(() => pub.ListenWithListener(url, Defines.NngFlag.NNG_FLAG_NONBLOCK));
+                using (var sub = Factory.SubscriberOpen().ThenDial(GetDialUrl(listener.Unwrap(), url)).Unwrap())
+                {
+
+                }
             }
         }
 
@@ -41,7 +61,7 @@ namespace nng.Tests
         {
             var url = UrlInproc();
             using (var socket = Factory.PublisherOpen().Unwrap())
-            using (var listener = Factory.ListenerCreate(socket, url))
+            using (var listener = socket.ListenerCreate(url).Unwrap())
             {
                 //AssertGetSetOpts(listener, NNG_OPT_RECVBUF, (int data) => data + 16);
                 AssertGetSetOpts(listener, NNG_OPT_RECVMAXSZ, (UIntPtr data) => data + 16);

--- a/tests/ReqRepTests.cs
+++ b/tests/ReqRepTests.cs
@@ -23,8 +23,10 @@ namespace nng.Tests
         [ClassData(typeof(TransportsClassData))]
         public async Task ReqRepBasic(string url)
         {
-            using (var repAioCtx = Factory.ReplierCreate(url).Unwrap().CreateAsyncContext(Factory).Unwrap())
-            using (var reqAioCtx = Factory.RequesterCreate(url).Unwrap().CreateAsyncContext(Factory).Unwrap())
+            using (var repSocket = Factory.ReplierOpen().ThenListenAs(out var listener, url).Unwrap())
+            using (var repAioCtx = repSocket.CreateAsyncContext(Factory).Unwrap())
+            using (var reqSocket = Factory.RequesterOpen().ThenDial(GetDialUrl(listener, url)).Unwrap())
+            using (var reqAioCtx = reqSocket.CreateAsyncContext(Factory).Unwrap())
             {
                 var receiveTask = repAioCtx.Receive();
                 var asyncReq = reqAioCtx.Send(Factory.CreateMessage());
@@ -44,11 +46,13 @@ namespace nng.Tests
         Task DoReqRep(string url)
         {
             var barrier = new AsyncBarrier(2);
+            var dialUrl = string.Empty;
             var rep = Task.Run(async () =>
             {
-                using (var socket = Factory.ReplierCreate(url).Unwrap())
+                using (var socket = Factory.ReplierOpen().ThenListenAs(out var listener, url).Unwrap())
                 using (var ctx = socket.CreateAsyncContext(Factory).Unwrap())
                 {
+                    dialUrl = GetDialUrl(listener, url);
                     await barrier.SignalAndWait();
 
                     var msg = await ctx.Receive();
@@ -59,7 +63,7 @@ namespace nng.Tests
             var req = Task.Run(async () =>
             {
                 await barrier.SignalAndWait();
-                using (var socket = Factory.RequesterCreate(url).Unwrap())
+                using (var socket = Factory.RequesterOpen().ThenDial(dialUrl).Unwrap())
                 using (var ctx = socket.CreateAsyncContext(Factory).Unwrap())
                 {
                     var _response = await ctx.Send(Factory.CreateMessage());
@@ -77,8 +81,8 @@ namespace nng.Tests
 
         void DoSendRecvAlloc(string url)
         {
-            using (var rep = Factory.ReplierCreate(url).Unwrap())
-            using (var req = Factory.RequesterCreate(url).Unwrap())
+            using (var rep = Factory.ReplierOpen().ThenListenAs(out var listener, url).Unwrap())
+            using (var req = Factory.RequesterOpen().ThenDial(GetDialUrl(listener, url)).Unwrap())
             {
                 var msg = Factory.CreateAlloc(128);
                 rng.NextBytes(msg.AsSpan());
@@ -97,28 +101,17 @@ namespace nng.Tests
             return Fixture.TestIterate(() => DoSendRecvNonBlock(url));
         }
 
-        async Task<NngResult<T>> retry<T>(Func<NngResult<T>> func)
-        {
-            NngResult<T> res = func();
-            while (res.IsErr(Defines.NngErrno.EAGAIN))
-            {
-                await Task.Delay(10);
-                res = func();
-            }
-            return res;
-        }
-
         async Task DoSendRecvNonBlock(string url)
         {
-            using (var rep = Factory.ReplierCreate(url).Unwrap())
-            using (var req = Factory.RequesterCreate(url).Unwrap())
+            using (var rep = Factory.ReplierOpen().ThenListenAs(out var listener, url).Unwrap())
+            using (var req = Factory.RequesterOpen().ThenDial(GetDialUrl(listener, url)).Unwrap())
             {
                 var msg = Factory.CreateMessage();
-                var res = await retry(() => req.SendMsg(msg, Defines.NngFlag.NNG_FLAG_NONBLOCK));
+                var res = await RetryAgain(() => req.SendMsg(msg, Defines.NngFlag.NNG_FLAG_NONBLOCK));
                 res.Unwrap();
-                var request = (await retry(() => rep.RecvMsg(Defines.NngFlag.NNG_FLAG_NONBLOCK))).Unwrap();
-                res = await retry(() => rep.SendMsg(request, Defines.NngFlag.NNG_FLAG_NONBLOCK));
-                var reply = await retry(() => req.RecvMsg(Defines.NngFlag.NNG_FLAG_NONBLOCK));
+                var request = (await RetryAgain(() => rep.RecvMsg(Defines.NngFlag.NNG_FLAG_NONBLOCK))).Unwrap();
+                res = await RetryAgain(() => rep.SendMsg(request, Defines.NngFlag.NNG_FLAG_NONBLOCK));
+                var reply = await RetryAgain(() => req.RecvMsg(Defines.NngFlag.NNG_FLAG_NONBLOCK));
                 reply.Unwrap();
             }
         }

--- a/tests/SocketTests.cs
+++ b/tests/SocketTests.cs
@@ -26,14 +26,14 @@ namespace nng.Tests
         [ClassData(typeof(BadTransportsClassData))]
         public void BadTransports(string url)
         {
-            Assert.True(Factory.PublisherCreate(url).IsErr());
-            Assert.True(Factory.PullerCreate(url, true).IsErr());
-            Assert.True(Factory.PullerCreate(url, false).IsErr());
-            Assert.True(Factory.PusherCreate(url, true).IsErr());
-            Assert.True(Factory.PusherCreate(url, false).IsErr());
-            Assert.True(Factory.ReplierCreate(url).IsErr());
-            Assert.True(Factory.RequesterCreate(url).IsErr());
-            Assert.True(Factory.SubscriberCreate(url).IsErr());
+            Assert.True(Factory.PublisherOpen().ThenListen(url).IsErr());
+            Assert.True(Factory.PullerOpen().ThenListen(url).IsErr());
+            Assert.True(Factory.PullerOpen().ThenDial(url).IsErr());
+            Assert.True(Factory.PusherOpen().ThenListen(url).IsErr());
+            Assert.True(Factory.PusherOpen().ThenDial(url).IsErr());
+            Assert.True(Factory.ReplierOpen().ThenListen(url).IsErr());
+            Assert.True(Factory.RequesterOpen().ThenDial(url).IsErr());
+            Assert.True(Factory.SubscriberOpen().ThenDial(url).IsErr());
         }
 
         // Test to verify result of constructing two of the same socket:
@@ -67,35 +67,35 @@ namespace nng.Tests
             var tests = new DupeUrlTest[] {
                 new DupeUrlTest (
                     null,
-                    () => Factory.PublisherCreate(url).Unwrap(),
+                    () => Factory.PublisherOpen().ThenListen(url).Unwrap(),
                     false),
                 new DupeUrlTest (
                     null,
-                    () => Factory.PullerCreate(url, true).Unwrap(),
+                    () => Factory.PullerOpen().ThenListen(url).Unwrap(),
                     false),
                 new DupeUrlTest (
-                    () => Factory.PusherCreate(url, true).Unwrap(),
-                    () => Factory.PullerCreate(url, false).Unwrap(),
+                    () => Factory.PusherOpen().ThenListen(url).Unwrap(),
+                    () => Factory.PullerOpen().ThenDial(url).Unwrap(),
                     true),
                 new DupeUrlTest (
                     null,
-                    () => Factory.PusherCreate(url, true).Unwrap(),
+                    () => Factory.PusherOpen().ThenListen(url).Unwrap(),
                     false),
                 new DupeUrlTest (
-                    () => Factory.PullerCreate(url, true).Unwrap(),
-                    () => Factory.PusherCreate(url, false).Unwrap(),
+                    () => Factory.PullerOpen().ThenListen(url).Unwrap(),
+                    () => Factory.PusherOpen().ThenDial(url).Unwrap(),
                     true),
                 new DupeUrlTest (
                     null,
-                    () => Factory.ReplierCreate(url).Unwrap(),
+                    () => Factory.ReplierOpen().ThenListen(url).Unwrap(),
                     false),
                 new DupeUrlTest (
-                    () => Factory.ReplierCreate(url).Unwrap(),
-                    () => Factory.RequesterCreate(url).Unwrap(),
+                    () => Factory.ReplierOpen().ThenListen(url).Unwrap(),
+                    () => Factory.RequesterOpen().ThenDial(url).Unwrap(),
                     true),
                 new DupeUrlTest (
-                    () => Factory.PublisherCreate(url).Unwrap(),
-                    () => Factory.SubscriberCreate(url).Unwrap(),
+                    () => Factory.PublisherOpen().ThenListen(url).Unwrap(),
+                    () => Factory.SubscriberOpen().ThenDial(url).Unwrap(),
                     true),
             };
 
@@ -141,8 +141,8 @@ namespace nng.Tests
 
         void DoGetSetOpt(string url)
         {
-            using (var rep = Factory.ReplierCreate(url).Unwrap())
-            using (var req = Factory.RequesterCreate(url).Unwrap())
+            using (var rep = Factory.ReplierOpen().ThenListenAs(out var listener, url).Unwrap())
+            using (var req = Factory.RequesterOpen().ThenDial(GetDialUrl(listener, url)).Unwrap())
             {
                 // bool
                 AssertGetSetOpts(req, NNG_OPT_TCP_NODELAY);

--- a/tests/StatsTests.cs
+++ b/tests/StatsTests.cs
@@ -27,9 +27,11 @@ namespace nng.Tests
         {
             // FIXME: Can be removed in nng 1.1.2 or 1.2.0
             // https://github.com/nanomsg/nng/issues/841
-            using (var pushSocket = Factory.PusherCreate("inproc://stats", true).Unwrap())
-            using (var pullSocket = Factory.PullerCreate("inproc://stats", false).Unwrap())
+            using (var pushSocket = Factory.PusherOpen().Unwrap())
+            using (var pullSocket = Factory.PullerOpen().Unwrap())
             {
+                pushSocket.Listen("inproc://stats").Unwrap();
+                pullSocket.Dial("inproc://stats").Unwrap();
                 using (var root = Factory.GetStatSnapshot().Unwrap())
                 {
                     foreach (var child in root.Child())

--- a/tests/Util.cs
+++ b/tests/Util.cs
@@ -23,13 +23,39 @@ namespace nng.Tests
 
         public static string UrlIpc() => "ipc://" + Guid.NewGuid().ToString();
         public static string UrlInproc() => "inproc://" + Guid.NewGuid().ToString();
-        public static string UrlTcp() => "tcp://localhost:" + rng.Next(1025, 65535);
+        public static string UrlTcp() => "tcp://localhost:0";
         public static string UrlWs() => "ws://localhost:" + rng.Next(1025, 65535) + "/" + rng.Next();
 
         public static byte[] TopicRandom() => Guid.NewGuid().ToByteArray();
 
         public static Task WaitReady() => Task.Delay(100);
         public static Task WaitShort() => Task.Delay(25);
+
+        public static string GetDialUrl(IListener listener, string url)
+        {
+            if (url.StartsWith("tcp", StringComparison.OrdinalIgnoreCase) && url.EndsWith(":0", StringComparison.OrdinalIgnoreCase))
+            {
+                var res = listener.GetOpt(nng.Native.Defines.NNG_OPT_LOCADDR, out nng_sockaddr addr);
+                if (res == 0)
+                {
+                    ushort port = 0;
+                    switch (addr.s_family)
+                    {
+                        case Native.nng_sockaddr_family.NNG_AF_INET:
+                        port = (ushort)System.Net.IPAddress.NetworkToHostOrder((short)addr.s_in.sa_port);
+                        break;
+                        case Native.nng_sockaddr_family.NNG_AF_INET6:
+                        port = (ushort)System.Net.IPAddress.NetworkToHostOrder((short)addr.s_in6.sa_port);
+                        break;
+                        default:
+                            Assert.True(false);
+                            break;
+                    }
+                    url = url.Substring(0, url.Length - 1) + port; 
+                }
+            }
+            return url;
+        }
 
         public static Task AssertWait(params Task[] tasks)
         {
@@ -122,6 +148,17 @@ namespace nng.Tests
                 return ex;
             }
             return null;
+        }
+
+        public static async Task<NngResult<T>> RetryAgain<T>(Func<NngResult<T>> func)
+        {
+            NngResult<T> res = func();
+            while (res.IsErr(Defines.NngErrno.EAGAIN))
+            {
+                await Task.Delay(10);
+                res = func();
+            }
+            return res;
         }
 
         public static readonly Random rng = new Random();


### PR DESCRIPTION
- Move dial/listen from factory to socket
- No longer need compound factory extension methods to create socket and dial/listen
- Tests TCP listener use ephemeral port and dialers use NNG_OPT_LOCADDR to access (#38)
- Should mitigate spurious EADDRINUSE for tcp transport
- Add tests for listener/dialer with NNG_FLAG_NONBLOCK (#37)